### PR TITLE
Pure Storage Cinder driver qos fixes and unit tests

### DIFF
--- a/cinder/tests/unit/volume/drivers/test_pure.py
+++ b/cinder/tests/unit/volume/drivers/test_pure.py
@@ -30,6 +30,7 @@ from cinder.tests.unit import fake_group_snapshot
 from cinder.tests.unit import fake_snapshot
 from cinder.tests.unit import fake_volume
 from cinder.tests.unit import test
+from cinder.volume import qos_specs
 from cinder.volume import volume_types
 from cinder.volume import volume_utils
 
@@ -497,6 +498,14 @@ MANAGEABLE_PURE_SNAP_REFS = [
     }
 ]
 
+# unit for maxBWS is MB
+QOS_IOPS_BWS = {"maxIOPS": "100", "maxBWS": "1"}
+QOS_IOPS_BWS_2 = {"maxIOPS": "1000", "maxBWS": "10"}
+QOS_INVALID = {"maxIOPS": "100", "maxBWS": str(512 * 1024 + 1)}
+QOS_ZEROS = {"maxIOPS": "0", "maxBWS": "0"}
+QOS_IOPS = {"maxIOPS": "100"}
+QOS_BWS = {"maxBWS": "1"}
+
 
 class FakePureStorageHTTPError(Exception):
     def __init__(self, target=None, rest_version=None, code=None,
@@ -580,7 +589,8 @@ class PureBaseSharedDriverTestCase(PureDriverTestCase):
         self.async_array2.get_rest_version.return_value = '1.4'
 
     def new_fake_vol(self, set_provider_id=True, fake_context=None,
-                     spec=None, type_extra_specs=None):
+                     spec=None, type_extra_specs=None, type_qos_specs_id=None,
+                     type_qos_specs=None):
         if fake_context is None:
             fake_context = mock.MagicMock()
         if type_extra_specs is None:
@@ -590,6 +600,8 @@ class PureBaseSharedDriverTestCase(PureDriverTestCase):
 
         voltype = fake_volume.fake_volume_type_obj(fake_context)
         voltype.extra_specs = type_extra_specs
+        voltype.qos_specs_id = type_qos_specs_id
+        voltype.qos_specs = type_qos_specs
 
         vol = fake_volume.fake_volume_obj(fake_context, **spec)
 
@@ -3109,6 +3121,191 @@ class PureBaseVolumeDriverTestCase(PureBaseSharedDriverTestCase):
         returned_wwn = self.driver._get_wwn(vol['name'])
         expected_wwn = '3624a93709714b5cb91634c470002b2c8'
         self.assertEqual(expected_wwn, returned_wwn)
+
+    @mock.patch.object(qos_specs, "get_qos_specs")
+    def test_get_qos_settings_from_specs_id(self, mock_get_qos_specs):
+        qos = qos_specs.create(mock.MagicMock(), "qos-iops-bws", QOS_IOPS_BWS)
+        mock_get_qos_specs.return_value = qos
+
+        voltype = fake_volume.fake_volume_type_obj(mock.MagicMock())
+        voltype.qos_specs_id = qos.id
+        voltype.extra_specs = QOS_IOPS_BWS_2  # test override extra_specs
+
+        specs = self.driver._get_qos_settings(voltype)
+        self.assertEqual(specs["maxIOPS"],
+                         int(QOS_IOPS_BWS["maxIOPS"]))
+        self.assertEqual(specs["maxBWS"],
+                         int(QOS_IOPS_BWS["maxBWS"]) * 1024 * 1024)
+
+    def test_get_qos_settings_from_extra_specs(self):
+        voltype = fake_volume.fake_volume_type_obj(mock.MagicMock())
+        voltype.extra_specs = QOS_IOPS_BWS
+
+        specs = self.driver._get_qos_settings(voltype)
+        self.assertEqual(specs["maxIOPS"],
+                         int(QOS_IOPS_BWS["maxIOPS"]))
+        self.assertEqual(specs["maxBWS"],
+                         int(QOS_IOPS_BWS["maxBWS"]) * 1024 * 1024)
+
+    def test_get_qos_settings_set_zeros(self):
+        voltype = fake_volume.fake_volume_type_obj(mock.MagicMock())
+        voltype.extra_specs = QOS_ZEROS
+        specs = self.driver._get_qos_settings(voltype)
+        self.assertEqual(specs["maxIOPS"], 0)
+        self.assertEqual(specs["maxBWS"], 0)
+
+    def test_get_qos_settings_set_one(self):
+        voltype = fake_volume.fake_volume_type_obj(mock.MagicMock())
+        voltype.extra_specs = QOS_IOPS
+        specs = self.driver._get_qos_settings(voltype)
+        self.assertEqual(specs["maxIOPS"], int(QOS_IOPS["maxIOPS"]))
+        self.assertEqual(specs["maxBWS"], 0)
+
+        voltype.extra_specs = QOS_BWS
+        specs = self.driver._get_qos_settings(voltype)
+        self.assertEqual(specs["maxIOPS"], 0)
+        self.assertEqual(specs["maxBWS"],
+                         int(QOS_BWS["maxBWS"]) * 1024 * 1024)
+
+    def test_get_qos_settings_invalid(self):
+        voltype = fake_volume.fake_volume_type_obj(mock.MagicMock())
+        voltype.extra_specs = QOS_INVALID
+        self.assertRaises(exception.InvalidQoSSpecs,
+                          self.driver._get_qos_settings,
+                          voltype)
+
+    @mock.patch(BASE_DRIVER_OBJ + "._add_to_group_if_needed")
+    @mock.patch(BASE_DRIVER_OBJ + "._get_replication_type_from_vol_type")
+    @mock.patch.object(qos_specs, "get_qos_specs")
+    @mock.patch.object(volume_types, 'get_volume_type')
+    def test_create_volume_with_qos(self, mock_get_volume_type,
+                                    mock_get_qos_specs,
+                                    mock_get_repl_type,
+                                    mock_add_to_group):
+        qos = qos_specs.create(mock.MagicMock(), "qos-iops-bws", QOS_IOPS_BWS)
+        vol, vol_name = self.new_fake_vol(spec={"size": 1},
+                                          type_qos_specs_id=qos.id)
+
+        mock_get_volume_type.return_value = vol.volume_type
+        self.array.get_rest_version.return_value = '1.17'
+        mock_get_qos_specs.return_value = qos
+        mock_get_repl_type.return_value = None
+
+        self.driver.create_volume(vol)
+        self.array.create_volume.assert_called_with(
+            vol_name, 1 * units.Gi,
+            iops_limit=int(QOS_IOPS_BWS["maxIOPS"]),
+            bandwidth_limit=int(QOS_IOPS_BWS["maxBWS"]) * 1024 * 1024)
+        mock_add_to_group.assert_called_once_with(vol,
+                                                  vol_name)
+        self.assert_error_propagates([self.array.create_volume],
+                                     self.driver.create_volume, vol)
+
+    @mock.patch(BASE_DRIVER_OBJ + "._add_to_group_if_needed")
+    @mock.patch(BASE_DRIVER_OBJ + "._get_replication_type_from_vol_type")
+    @mock.patch.object(qos_specs, "get_qos_specs")
+    @mock.patch.object(volume_types, 'get_volume_type')
+    def test_create_volume_from_snapshot_with_qos(self, mock_get_volume_type,
+                                                  mock_get_qos_specs,
+                                                  mock_get_repl_type,
+                                                  mock_add_to_group):
+        srcvol, _ = self.new_fake_vol()
+        snap = fake_snapshot.fake_snapshot_obj(mock.MagicMock(), volume=srcvol)
+        snap_name = snap["volume_name"] + "-cinder." + snap["name"]
+        qos = qos_specs.create(mock.MagicMock(), "qos-iops-bws", QOS_IOPS_BWS)
+        vol, vol_name = self.new_fake_vol(set_provider_id=False,
+                                          type_qos_specs_id=qos.id)
+
+        mock_get_volume_type.return_value = vol.volume_type
+        self.array.get_rest_version.return_value = '1.17'
+        mock_get_qos_specs.return_value = qos
+        mock_get_repl_type.return_value = None
+
+        self.driver.create_volume_from_snapshot(vol, snap)
+        self.array.copy_volume.assert_called_with(snap_name, vol_name)
+        self.array.set_volume.assert_called_with(
+            vol_name,
+            iops_limit=int(QOS_IOPS_BWS["maxIOPS"]),
+            bandwidth_limit=int(QOS_IOPS_BWS["maxBWS"]) * 1024 * 1024)
+        self.assertFalse(self.array.extend_volume.called)
+        mock_add_to_group.assert_called_once_with(vol, vol_name)
+        self.assert_error_propagates(
+            [self.array.copy_volume],
+            self.driver.create_volume_from_snapshot, vol, snap)
+        self.assertFalse(self.array.extend_volume.called)
+
+    @mock.patch.object(qos_specs, "get_qos_specs")
+    @mock.patch.object(volume_types, 'get_volume_type')
+    def test_manage_existing_with_qos(self, mock_get_volume_type,
+                                      mock_get_qos_specs):
+        ref_name = 'vol1'
+        volume_ref = {'name': ref_name}
+        qos = qos_specs.create(mock.MagicMock(), "qos-iops-bws", QOS_IOPS_BWS)
+        vol, vol_name = self.new_fake_vol(set_provider_id=False,
+                                          type_qos_specs_id=qos.id)
+
+        mock_get_volume_type.return_value = vol.volume_type
+        mock_get_qos_specs.return_value = qos
+        self.array.list_volume_private_connections.return_value = []
+        self.array.get_rest_version.return_value = '1.17'
+
+        self.driver.manage_existing(vol, volume_ref)
+        self.array.list_volume_private_connections.assert_called_with(ref_name)
+        self.array.rename_volume.assert_called_with(ref_name, vol_name)
+        self.array.set_volume.assert_called_with(
+            vol_name,
+            iops_limit=int(QOS_IOPS_BWS["maxIOPS"]),
+            bandwidth_limit=int(QOS_IOPS_BWS["maxBWS"]) * 1024 * 1024)
+
+    def test_retype_qos(self):
+        mock_context = mock.MagicMock()
+        vol, vol_name = self.new_fake_vol()
+        qos = qos_specs.create(mock.MagicMock(), "qos-iops-bws", QOS_IOPS_BWS)
+        new_type = fake_volume.fake_volume_type_obj(mock_context)
+        new_type.qos_specs_id = qos.id
+
+        self.array.get_rest_version.return_value = '1.17'
+        get_voltype = "cinder.objects.volume_type.VolumeType.get_by_name_or_id"
+        with mock.patch(get_voltype) as mock_get_vol_type:
+            mock_get_vol_type.return_value = new_type
+            did_retype, model_update = self.driver.retype(
+                mock_context,
+                vol,
+                new_type,
+                None,  # ignored by driver
+                None,  # ignored by driver
+            )
+
+        self.array.set_volume.assert_called_with(
+            vol_name,
+            iops_limit=int(QOS_IOPS_BWS["maxIOPS"]),
+            bandwidth_limit=int(QOS_IOPS_BWS["maxBWS"]) * 1024 * 1024)
+        self.assertTrue(did_retype)
+        self.assertIsNone(model_update)
+
+    def test_retype_qos_reset_iops(self):
+        mock_context = mock.MagicMock()
+        vol, vol_name = self.new_fake_vol()
+        new_type = fake_volume.fake_volume_type_obj(mock_context)
+
+        self.array.get_rest_version.return_value = '1.17'
+        get_voltype = "cinder.objects.volume_type.VolumeType.get_by_name_or_id"
+        with mock.patch(get_voltype) as mock_get_vol_type:
+            mock_get_vol_type.return_value = new_type
+            did_retype, model_update = self.driver.retype(
+                mock_context,
+                vol,
+                new_type,
+                None,  # ignored by driver
+                None,  # ignored by driver
+            )
+
+        self.array.set_volume.assert_called_with(
+            vol_name,
+            iops_limit="",
+            bandwidth_limit="")
+        self.assertTrue(did_retype)
+        self.assertIsNone(model_update)
 
 
 class PureISCSIDriverTestCase(PureBaseSharedDriverTestCase):


### PR DESCRIPTION
* `_get_qos_settings` returns `None` if no qos specs provided
* `_get_qos_settings` returns both `maxIOPS` and `maxBWS` values if one or more specs provided, return value for missing spec will be 0, and values are int type
* `_get_qos_settings` value validation fixed to pass new unit tests
* result check for `_get_qos_settings` type fixed when calling
* failing unit tests fixed for patch 14 https://review.opendev.org/c/openstack/cinder/+/727267/14
* bunch of unit tests added